### PR TITLE
Fix 404 - not found error handling 

### DIFF
--- a/es_service.go
+++ b/es_service.go
@@ -32,19 +32,32 @@ func (service esService) loadData(conceptType string, uuid string, payload inter
 }
 
 func (service esService) readData(conceptType string, uuid string) (*elastic.GetResult, error) {
-	return service.elasticClient.Get().
+	resp, err := service.elasticClient.Get().
 		Index(service.indexName).
 		Type(conceptType).
 		Id(uuid).
+		IgnoreErrorsOnGeneratedFields(false).
 		Do()
+
+	if elastic.IsNotFound(err) {
+		return &elastic.GetResult{Found:false}, nil
+	} else {
+		return resp, err
+	}
 }
 
 func (service esService) deleteData(conceptType string, uuid string) (*elastic.DeleteResponse, error) {
-	return service.elasticClient.Delete().
+	resp, err := service.elasticClient.Delete().
 		Index(service.indexName).
 		Type(conceptType).
 		Id(uuid).
 		Do()
+
+	if elastic.IsNotFound(err) {
+		return &elastic.DeleteResponse{Found:false}, nil
+	} else {
+		return resp, err
+	}
 }
 
 func (service esService) loadBulkData(conceptType string, uuid string, payload interface{}) {


### PR DESCRIPTION
The elastic go library (v3) doesn't have a specific handler for 404 (not found) messages, so the expected behaviour of setting the object Response{Found:false} needs to be done by us.

The affected endpoints are only for internal usage, no tests added (we could have integration tests at some point).