### PR TITLE
Support writes only for whitelisted concept types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Other parameters:
 - bulk-requests
 - bulk-size
 - flush-interval
+- whitelisted-concepts - comma separated values with concept types that are supported by this writer. This is important if we don't want to end-up with automatically defined mapping types in our index.
+
+The currently supported concept types are: "genres,topics,sections,subjects,locations,brands,organisations,people".
 
 ## Available DATA endpoints:
 

--- a/es_service.go
+++ b/es_service.go
@@ -40,7 +40,7 @@ func (service esService) readData(conceptType string, uuid string) (*elastic.Get
 		Do()
 
 	if elastic.IsNotFound(err) {
-		return &elastic.GetResult{Found:false}, nil
+		return &elastic.GetResult{Found: false}, nil
 	} else {
 		return resp, err
 	}
@@ -54,7 +54,7 @@ func (service esService) deleteData(conceptType string, uuid string) (*elastic.D
 		Do()
 
 	if elastic.IsNotFound(err) {
-		return &elastic.DeleteResponse{Found:false}, nil
+		return &elastic.DeleteResponse{Found: false}, nil
 	} else {
 		return resp, err
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -52,9 +52,7 @@ func TestLoadData(t *testing.T) {
 			status, http.StatusOK)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestLoadDataBadRequest(t *testing.T) {
@@ -80,9 +78,7 @@ func TestLoadDataBadRequest(t *testing.T) {
 			status, http.StatusBadRequest)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestLoadDataBadRequestForUnsupportedType(t *testing.T) {
@@ -108,9 +104,7 @@ func TestLoadDataBadRequestForUnsupportedType(t *testing.T) {
 			status, http.StatusOK)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestLoadDataBadRequestForEmptyType(t *testing.T) {
@@ -136,9 +130,7 @@ func TestLoadDataBadRequestForEmptyType(t *testing.T) {
 			status, http.StatusBadRequest)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestLoadDataBadRequestForEmptyPrefLabel(t *testing.T) {
@@ -164,9 +156,7 @@ func TestLoadDataBadRequestForEmptyPrefLabel(t *testing.T) {
 			status, http.StatusBadRequest)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestLoadDataEsClientServerErrors(t *testing.T) {
@@ -192,9 +182,7 @@ func TestLoadDataEsClientServerErrors(t *testing.T) {
 			status, http.StatusInternalServerError)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestLoadDataIncorrectPayload(t *testing.T) {
@@ -220,9 +208,7 @@ func TestLoadDataIncorrectPayload(t *testing.T) {
 			status, http.StatusInternalServerError)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestLoadBulkDataIncorrectPayload(t *testing.T) {
@@ -248,9 +234,7 @@ func TestLoadBulkDataIncorrectPayload(t *testing.T) {
 			status, http.StatusInternalServerError)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestLoadBulkDataBadRequest(t *testing.T) {
@@ -276,9 +260,7 @@ func TestLoadBulkDataBadRequest(t *testing.T) {
 			status, http.StatusBadRequest)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestReadData(t *testing.T) {
@@ -350,9 +332,7 @@ func TestReadDataNotFound(t *testing.T) {
 			status, http.StatusNotFound)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestReadDataEsServerError(t *testing.T) {
@@ -376,9 +356,7 @@ func TestReadDataEsServerError(t *testing.T) {
 			status, http.StatusInternalServerError)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestDeleteData(t *testing.T) {
@@ -403,9 +381,7 @@ func TestDeleteData(t *testing.T) {
 			status, http.StatusOK)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestDeleteDataNotFound(t *testing.T) {
@@ -430,9 +406,7 @@ func TestDeleteDataNotFound(t *testing.T) {
 			status, http.StatusNotFound)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 func TestDeleteDataEsServerError(t *testing.T) {
@@ -457,9 +431,7 @@ func TestDeleteDataEsServerError(t *testing.T) {
 			status, http.StatusInternalServerError)
 	}
 
-	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
-	}
+	assert.Nil(t, rr.Body.Bytes(), "Response body should be empty")
 }
 
 type dummyEsService struct {

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -80,7 +80,7 @@ func TestHealthDetailsReturnsError(t *testing.T) {
 	}
 
 	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
+		t.Error("Response body should be empty")
 	}
 }
 
@@ -109,7 +109,7 @@ func TestGoodToGoHealthyCluster(t *testing.T) {
 	}
 
 	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
+		t.Error("Response body should be empty")
 	}
 }
 
@@ -138,7 +138,7 @@ func TestGoodToGoUnhealthyCluster(t *testing.T) {
 	}
 
 	if rr.Body.Bytes() != nil {
-		t.Errorf("Response body should be empty")
+		t.Error("Response body should be empty")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 
 	elasticsearchWhitelistedConceptTypes := app.String(cli.StringOpt{
 		Name:   "whitelisted-concepts",
+		Value:  "genres,topics,sections,subjects,locations,brands,organisations,people",
 		Desc:   "List which are currently supported by elasticsearch (already have mapping associated)",
 		EnvVar: "ELASTICSEARCH_WHITELISTED_CONCEPTS",
 	})

--- a/model_conversion_test.go
+++ b/model_conversion_test.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestConvertToESConceptModel(t *testing.T) {

--- a/model_conversion_test.go
+++ b/model_conversion_test.go
@@ -82,12 +82,12 @@ func TestConvertToESConceptModel(t *testing.T) {
 
 	for _, testModel := range tests {
 		esModel := convertToESConceptModel(testModel.conceptModel, "organisations")
-		assert.Equal(testModel.esConceptModel.Id, esModel.Id, fmt.Sprintf("Expected Id %s differs from actual id %d ", testModel.esConceptModel.Id, esModel.Id))
-		assert.Equal(testModel.esConceptModel.ApiUrl, esModel.ApiUrl, fmt.Sprintf("Expected ApiUrl %s differs from actual ApiUrl %d ", testModel.esConceptModel.ApiUrl, esModel.ApiUrl))
-		assert.Equal(testModel.esConceptModel.DirectType, esModel.DirectType, fmt.Sprintf("Expected DirectType %s differs from actual DirectType %d ", testModel.esConceptModel.DirectType, esModel.DirectType))
-		assert.Equal(testModel.esConceptModel.PrefLabel, esModel.PrefLabel, fmt.Sprintf("Expected PrefLabel %s differs from actual PrefLabel %d ", testModel.esConceptModel.PrefLabel, esModel.PrefLabel))
-		assert.Equal(testModel.esConceptModel.Types, esModel.Types, fmt.Sprintf("Expected Types %s differ from actual Types %d ", testModel.esConceptModel.Types, esModel.Types))
-		assert.Equal(testModel.esConceptModel.Aliases, esModel.Aliases, fmt.Sprintf("Expected Aliases %s differ from actual Aliases %d ", testModel.esConceptModel.Aliases, esModel.Aliases))
+		assert.Equal(testModel.esConceptModel.Id, esModel.Id, fmt.Sprintf("Expected Id %s differs from actual id %s ", testModel.esConceptModel.Id, esModel.Id))
+		assert.Equal(testModel.esConceptModel.ApiUrl, esModel.ApiUrl, fmt.Sprintf("Expected ApiUrl %s differs from actual ApiUrl %s ", testModel.esConceptModel.ApiUrl, esModel.ApiUrl))
+		assert.Equal(testModel.esConceptModel.DirectType, esModel.DirectType, fmt.Sprintf("Expected DirectType %s differs from actual DirectType %s ", testModel.esConceptModel.DirectType, esModel.DirectType))
+		assert.Equal(testModel.esConceptModel.PrefLabel, esModel.PrefLabel, fmt.Sprintf("Expected PrefLabel %s differs from actual PrefLabel %s ", testModel.esConceptModel.PrefLabel, esModel.PrefLabel))
+		assert.Equal(testModel.esConceptModel.Types, esModel.Types, fmt.Sprintf("Expected Types %s differ from actual Types %s ", testModel.esConceptModel.Types, esModel.Types))
+		assert.Equal(testModel.esConceptModel.Aliases, esModel.Aliases, fmt.Sprintf("Expected Aliases %s differ from actual Aliases %s ", testModel.esConceptModel.Aliases, esModel.Aliases))
 	}
 
 }


### PR DESCRIPTION
Adding this support to avoid concept types without manually defined mapping ending up in elasticsearch.
(At a later phase it is harder to change an index mapping, also, it is not trivial to delete all the inserted document for an index/type)