### PR TITLE
Add autocomplete support for about and mentions.

### DIFF
--- a/deployment_notes_25052017.md
+++ b/deployment_notes_25052017.md
@@ -11,23 +11,26 @@ GET http://upp-concepts-dynpub-eu.in.ft.com/concepts-0.0.1/_mappings
 
 ## 2) Copy all the data from the original concept index into the new concepts-0.0.1 index
 
-POST http://upp-concepts-dynpub-eu.in.ft.com/_reindex
+`POST http://upp-concepts-dynpub-eu.in.ft.com/_reindex?wait_for_completion=false`
 
-`{
+```
+{
   "source": {
     "index": "concept"
   },
   "dest": {
     "index": "concepts-0.0.1"
   }
-}`
+}
+```
+Note that the source index can be an _alias_.
 
-This is asynchronous and somehow you can tell its status by the _tasks endpoint. I am usually check that the GET for this collection is the expected total value.
+This is asynchronous and somehow you can tell its status by the _tasks endpoint. I usually check that the GET for this collection is the expected total value.
 e.g.
 
 GET http://upp-concepts-dynpub-eu.in.ft.com/concepts-0.0.1/_search
 hits.total = 7666522
-
+- You can also check this using the AWS console, by expanding the index name on the Indices tab.
 
 
 ## 3) Create alias CONCEPTS that points to the versioned index
@@ -51,11 +54,11 @@ POST upp-concepts-dynpub-eu.in.ft.com/concepts/_search
 
 `{
   "suggest" : {
-	    "mysuggestion" :  {
-	    "text" : "Lucy K",
-	    "completion" : {
-	      "field" : "prefLabel.indexCompletion"
-	    }
+        "mysuggestion" :  {
+        "text" : "Lucy K",
+        "completion" : {
+          "field" : "prefLabel.mentionsCompletion"
+        }
     }
   }
 } `

--- a/mapping.json
+++ b/mapping.json
@@ -25,6 +25,9 @@
             "raw": {
               "type": "string",
               "index": "not_analyzed"
+            },
+            "mentionsCompletion": {
+              "type": "completion"
             }
           }
         },
@@ -66,7 +69,7 @@
               "type": "string",
               "index": "not_analyzed"
             },
-            "indexCompletion": {
+            "mentionsCompletion": {
               "type": "completion"
             },
             "completionByContext": {
@@ -116,6 +119,9 @@
             "raw": {
               "type": "string",
               "index": "not_analyzed"
+            },
+            "mentionsCompletion": {
+              "type": "completion"
             }
           }
         },
@@ -237,9 +243,6 @@
               "type": "string",
               "index": "not_analyzed"
             },
-            "indexCompletion": {
-              "type": "completion"
-            },
             "completionByContext": {
               "type": "completion",
               "contexts": [{
@@ -327,6 +330,9 @@
             "raw": {
               "type": "string",
               "index": "not_analyzed"
+            },
+            "mentionsCompletion": {
+              "type": "completion"
             }
           }
         },


### PR DESCRIPTION
- Rename the field prefLabel.indexCompletion to the more specific and
clearer prefLabel.mentionsCompletion ("about" being a kind of "mention")
- Remove prefLabel.indexCompletion from brands
- Add prefLabel.indexCompletion to people, organisations, locations and
topics