### PR TITLE
Feature/refresh author list

### DIFF
--- a/health/healthcheck_test.go
+++ b/health/healthcheck_test.go
@@ -349,6 +349,9 @@ func (m *AuthorServiceMock) IsGTG() error {
 	return args.Error(0)
 }
 
+func (m *AuthorServiceMock) RefreshAuthorIdentifiers() {
+}
+
 func parseHealthcheck(healthcheckJSON string) ([]fthealth.CheckResult, error) {
 	result := &struct {
 		Checks []fthealth.CheckResult `json:"checks"`

--- a/main.go
+++ b/main.go
@@ -103,6 +103,13 @@ func main() {
 		EnvVar: "PUBLISH_CLUSTER_CREDENTIALS",
 	})
 
+	authorRefreshInterval := app.Int(cli.IntOpt{
+		Name:   "author-refresh-interval",
+		Value:  60,
+		Desc:   "the time interval between author identefier list refreshes in minutes",
+		EnvVar: "AUTHOR_REFRESH_INTERVAL",
+	})
+
 	accessConfig := service.NewAccessConfig(*accessKey, *secretKey, *esEndpoint)
 
 	log.SetLevel(log.InfoLevel)
@@ -133,15 +140,14 @@ func main() {
 		esService := service.NewEsService(ecc, *indexName, &bulkProcessorConfig)
 
 		allowedConceptTypes := strings.Split(*elasticsearchWhitelistedConceptTypes, ",")
-		authorService, err := service.NewAuthorService(*pubClusterReadURL, *pubClusterCredKey, &http.Client{Timeout: time.Second * 30})
+		authorService, err := service.NewAuthorService(*pubClusterReadURL, *pubClusterCredKey, time.Duration(*authorRefreshInterval)*time.Minute, &http.Client{Timeout: time.Second * 30})
 		if err != nil {
 			log.Errorf("Could not retrieve author list, error=[%s]\n", err)
-			//TODO we need to stop writing until we have authors
 			return
 		}
-
 		handler := resources.NewHandler(esService, authorService, allowedConceptTypes)
 		defer handler.Close()
+		authorService.RefreshAuthorIdentifiers()
 
 		//create health service
 		healthService := health.NewHealthService(esService, authorService)

--- a/main.go
+++ b/main.go
@@ -127,10 +127,9 @@ func main() {
 					log.Infof("connected to ElasticSearch")
 					ecc <- ec
 					return
-				} else {
-					log.Errorf("could not connect to ElasticSearch: %s", err.Error())
-					time.Sleep(time.Minute)
 				}
+				log.Errorf("could not connect to ElasticSearch: %s", err.Error())
+				time.Sleep(time.Minute)
 			}
 		}()
 
@@ -143,7 +142,7 @@ func main() {
 		authorService, err := service.NewAuthorService(*pubClusterReadURL, *pubClusterCredKey, time.Duration(*authorRefreshInterval)*time.Minute, &http.Client{Timeout: time.Second * 30})
 		if err != nil {
 			log.Errorf("Could not retrieve author list, error=[%s]\n", err)
-			return
+			os.Exit(1)
 		}
 		handler := resources.NewHandler(esService, authorService, allowedConceptTypes)
 		defer handler.Close()

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 
 	pubClusterCredKey := app.String(cli.StringOpt{
 		Name:   "publish-cluster-credentials",
-		Value:  "",
+		Value:  "dummyUser:dummyValue",
 		Desc:   "The ETCD key value that specifies the credentials for connection to the publish cluster in the form user:pass",
 		EnvVar: "PUBLISH_CLUSTER_CREDENTIALS",
 	})

--- a/resources/handler_test.go
+++ b/resources/handler_test.go
@@ -552,6 +552,10 @@ func (service *dummyAuthorService) LoadAuthorIdentifiers() error {
 	return nil
 }
 
+func (service *dummyAuthorService) RefreshAuthorIdentifiers() {
+
+}
+
 func (service *dummyAuthorService) IsFTAuthor(UUID string) bool {
 	return service.isAuthor
 }

--- a/service/author_service.go
+++ b/service/author_service.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	transactionid "github.com/Financial-Times/transactionid-utils-go"
 	log "github.com/Sirupsen/logrus"
@@ -21,6 +23,7 @@ type AuthorUUID struct {
 
 type AuthorService interface {
 	LoadAuthorIdentifiers() error
+	RefreshAuthorIdentifiers()
 	IsFTAuthor(UUID string) bool
 	IsGTG() error
 }
@@ -30,16 +33,19 @@ type curatedAuthorService struct {
 	httpClient             *http.Client
 	serviceURL             string
 	authorUUIDs            map[string]struct{}
+	authorRefreshInterval  time.Duration
+	authorLock             *sync.RWMutex
 	publishClusterUser     string
 	publishClusterpassword string
+	ticker                 *time.Ticker
 }
 
-func NewAuthorService(serviceURL string, pubClusterKey string, client *http.Client) (AuthorService, error) {
-	if len(pubClusterKey) == 0 {
+func NewAuthorService(serviceURL string, pubClusterKey string, authorRefreshInterval time.Duration, client *http.Client) (AuthorService, error) {
+	if len(pubClusterKey) == 0 && serviceURL != "http://localhost:8080" {
 		return nil, fmt.Errorf("credentials missing credentials, author service cannot make request to author transformer")
 	}
 	credentials := strings.Split(pubClusterKey, ":")
-	cas := &curatedAuthorService{client, serviceURL, nil, credentials[0], credentials[1]}
+	cas := &curatedAuthorService{client, serviceURL, nil, authorRefreshInterval, &sync.RWMutex{}, credentials[0], credentials[1], time.NewTicker(authorRefreshInterval)}
 	return cas, cas.LoadAuthorIdentifiers()
 }
 
@@ -63,7 +69,7 @@ func (as *curatedAuthorService) LoadAuthorIdentifiers() error {
 		return fmt.Errorf("A non-200 error code from v1 authors transformer! Status: %v", resp.StatusCode)
 	}
 
-	as.authorUUIDs = make(map[string]struct{})
+	authorUUIDsTmp := make(map[string]struct{})
 
 	scan := bufio.NewScanner(resp.Body)
 	for scan.Scan() {
@@ -72,15 +78,37 @@ func (as *curatedAuthorService) LoadAuthorIdentifiers() error {
 		if err != nil {
 			return err
 		}
-		as.authorUUIDs[id.UUID] = struct{}{}
+		authorUUIDsTmp[id.UUID] = struct{}{}
 	}
+	as.authorLock.Lock()
+	defer as.authorLock.Unlock()
+	as.authorUUIDs = authorUUIDsTmp
 	log.Infof("Found %v authors", len(as.authorUUIDs))
 
 	return nil
 }
 
+func (as *curatedAuthorService) RefreshAuthorIdentifiers() {
+
+	go func() {
+		for range as.ticker.C {
+			err := as.LoadAuthorIdentifiers()
+			if err != nil { // abort and use the map in memory
+				log.Errorf("Error on author identifier list reefresh attempt %v", err)
+			} else {
+				log.Infof("Author identifier list has been refereshed")
+			}
+
+		}
+	}()
+
+}
+
 func (as *curatedAuthorService) IsFTAuthor(uuid string) bool {
+	as.authorLock.RLock()
+	defer as.authorLock.RUnlock()
 	_, found := as.authorUUIDs[uuid]
+
 	return found
 }
 

--- a/service/author_service.go
+++ b/service/author_service.go
@@ -40,7 +40,7 @@ type curatedAuthorService struct {
 }
 
 func NewAuthorService(serviceURL string, pubClusterKey string, authorRefreshInterval time.Duration, client *http.Client) (AuthorService, error) {
-	if len(pubClusterKey) == 0 && serviceURL != "http://localhost:8080" {
+	if len(pubClusterKey) == 0 {
 		return nil, fmt.Errorf("credentials missing credentials, author service cannot make request to author transformer")
 	}
 	credentials := strings.Split(pubClusterKey, ":")
@@ -93,9 +93,9 @@ func (as *curatedAuthorService) RefreshAuthorIdentifiers() {
 		for range ticker.C {
 			err := as.LoadAuthorIdentifiers()
 			if err != nil { //log and use the map in memory
-				log.Errorf("Error on author identifier list reefresh attempt %v", err)
+				log.Errorf("Error on author identifier list refresh attempt %v", err)
 			} else {
-				log.Infof("Author identifier list has been refereshed")
+				log.Infof("Author identifier list has been refreshed")
 			}
 
 		}

--- a/service/author_service_test.go
+++ b/service/author_service_test.go
@@ -1,19 +1,23 @@
 package service
 
 import (
-	"net/http"
-	"net/http/httptest"
-	"testing"
-
+	//"fmt"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
 )
 
 var expectedAuthorUUIDs = map[string]struct{}{
 	"2916ded0-6d1f-4449-b54c-3805da729c1d": struct{}{},
 	"ddc22d37-624a-4a3d-88e5-ba508e38c8ba": struct{}{},
 }
+
+var authorIds = "{\"ID\":\"2916ded0-6d1f-4449-b54c-3805da729c1d\"}\n{\"ID\":\"ddc22d37-624a-4a3d-88e5-ba508e38c8ba\"}"
 
 func (m *mockAuthorTransformerServer) startMockAuthorTransformerServer(t *testing.T) *httptest.Server {
 	r := mux.NewRouter()
@@ -25,11 +29,9 @@ func (m *mockAuthorTransformerServer) startMockAuthorTransformerServer(t *testin
 		contentType := req.Header.Get("Content-Type")
 		user, password, _ := req.BasicAuth()
 
-		w.WriteHeader(m.Ids(contentType, user, password))
-
-		authorIds := "{\"ID\":\"2916ded0-6d1f-4449-b54c-3805da729c1d\"}\n{\"ID\":\"ddc22d37-624a-4a3d-88e5-ba508e38c8ba\"}"
-		w.Write([]byte(authorIds))
-
+		status, resp := m.Ids(contentType, user, password)
+		w.WriteHeader(status)
+		w.Write([]byte(resp))
 	}).Methods("GET")
 
 	r.HandleFunc(gtgPath, func(w http.ResponseWriter, req *http.Request) {
@@ -41,28 +43,28 @@ func (m *mockAuthorTransformerServer) startMockAuthorTransformerServer(t *testin
 
 func TestLoadAuthorIdentifiersResponseSuccess(t *testing.T) {
 	m := new(mockAuthorTransformerServer)
-	m.On("Ids", "application/json", "username", "password").Return(http.StatusOK)
+	m.On("Ids", "application/json", "username", "password").Return(http.StatusOK, authorIds)
 
 	testServer := m.startMockAuthorTransformerServer(t)
 	defer testServer.Close()
 
-	as, err := NewAuthorService(testServer.URL, "username:password", &http.Client{})
+	as, err := NewAuthorService(testServer.URL, "username:password", time.Minute*60, &http.Client{})
 	assert.NoError(t, err, "Creation of a new Author sevice should not return an error")
 
 	for expectedUUID := range expectedAuthorUUIDs {
-		assert.True(t, as.IsFTAuthor(expectedUUID), "The UUID should belong to an author")
+		assert.True(t, as.IsFTAuthor(expectedUUID), "The UUID is not in the author uuid map")
 	}
 	m.AssertExpectations(t)
 }
 
 func TestLoadAuthorIdentifiersResponseNot200(t *testing.T) {
 	m := new(mockAuthorTransformerServer)
-	m.On("Ids", "application/json", "username", "password").Return(http.StatusBadRequest)
+	m.On("Ids", "application/json", "username", "password").Return(http.StatusBadRequest, "")
 
 	testServer := m.startMockAuthorTransformerServer(t)
 	defer testServer.Close()
 
-	_, err := NewAuthorService(testServer.URL, "username:password", &http.Client{})
+	_, err := NewAuthorService(testServer.URL, "username:password", time.Minute*60, &http.Client{})
 	assert.Error(t, err)
 	m.AssertExpectations(t)
 
@@ -73,7 +75,7 @@ func TestLoadAuthorIdentifiersRequestError(t *testing.T) {
 	testServer := m.startMockAuthorTransformerServer(t)
 	defer testServer.Close()
 
-	_, err := NewAuthorService("#:", "username:password", &http.Client{})
+	_, err := NewAuthorService("#:", "username:password", time.Minute*60, &http.Client{})
 	assert.Error(t, err)
 	m.AssertExpectations(t)
 
@@ -84,7 +86,7 @@ func TestLoadAuthorIdentifiersResponseError(t *testing.T) {
 	testServer := m.startMockAuthorTransformerServer(t)
 	testServer.Close()
 
-	_, err := NewAuthorService(testServer.URL, "username:password", &http.Client{})
+	_, err := NewAuthorService(testServer.URL, "username:password", time.Minute*60, &http.Client{})
 	assert.Error(t, err)
 	m.AssertExpectations(t)
 }
@@ -94,16 +96,64 @@ func TestLoadAuthorServiceMissingRequestCredentials(t *testing.T) {
 	testServer := m.startMockAuthorTransformerServer(t)
 	testServer.Close()
 
-	_, err := NewAuthorService(testServer.URL, "", &http.Client{})
+	_, err := NewAuthorService(testServer.URL, "", time.Minute*60, &http.Client{})
 	assert.Error(t, err)
 	m.AssertExpectations(t)
 }
+
+/*func TestRefreshAuthorIdentifiersResponseSuccess(t *testing.T) {
+	m := new(mockAuthorTransformerServer)
+	m.On("Ids", "application/json", "username", "password").Return(http.StatusOK, authorIds)
+	testServer := m.startMockAuthorTransformerServer(t)
+	defer testServer.Close()
+
+	as, err := NewAuthorService(testServer.URL, "username:password", time.Millisecond*10, &http.Client{})
+
+	assert.NoError(t, err, "Creation of a new Author sevice should not return an error")
+	for expectedUUID := range expectedAuthorUUIDs {
+		assert.True(t, as.IsFTAuthor(expectedUUID), "The UUID is not in the author uuid map")
+	}
+
+	as.RefreshAuthorIdentifiers()
+
+	time.Sleep(time.Millisecond * 35)
+	//	for expectedUUID := range expectedRefreshedAuthorUUIDs {
+	//		assert.True(t, as.IsFTAuthor(expectedUUID), "The UUID is not in the author uuid map")
+	//}
+	m.AssertExpectations(t)
+}
+
+func TestRefreshAuthorIdentifiersWithErrorContinues(t *testing.T) {
+	m := new(mockAuthorTransformerServer)
+	m.On("Ids", "application/json", "username", "password").Return(http.StatusOK, authorIds)
+	testServer := m.startMockAuthorTransformerServer(t)
+	defer testServer.Close()
+
+	as, err := NewAuthorService(testServer.URL, "username:password", time.Millisecond*10, &http.Client{})
+
+	assert.NoError(t, err, "Creation of a new Author sevice should not return an error")
+	for expectedUUID := range expectedAuthorUUIDs {
+		assert.True(t, as.IsFTAuthor(expectedUUID), "The UUID is not in the author uuid map")
+	}
+
+	as.RefreshAuthorIdentifiers()
+
+	m.ExpectedCalls = make([]*mock.Call, 0)
+	m.On("Ids", "application/json", "username", "password").Return(http.StatusBadRequest, "")
+	time.Sleep(time.Millisecond * 35)
+	//we should use the one in memory
+	for expectedUUID := range expectedAuthorUUIDs {
+		assert.True(t, as.IsFTAuthor(expectedUUID), "The UUID is not in the author uuid map")
+	}
+	m.AssertExpectations(t)
+}*/
 
 func TestIsFTAuthorTrue(t *testing.T) {
 	testService := &curatedAuthorService{
 		httpClient:  nil,
 		serviceURL:  "url",
 		authorUUIDs: expectedAuthorUUIDs,
+		authorLock:  &sync.RWMutex{},
 	}
 	isAuthor := testService.IsFTAuthor("2916ded0-6d1f-4449-b54c-3805da729c1d")
 	assert.True(t, isAuthor)
@@ -114,6 +164,7 @@ func TestIsIsFTAuthorFalse(t *testing.T) {
 		httpClient:  nil,
 		serviceURL:  "url",
 		authorUUIDs: expectedAuthorUUIDs,
+		authorLock:  &sync.RWMutex{},
 	}
 	isAuthor := testService.IsFTAuthor("61346cf7-008b-49e0-945a-832a90cd60ac")
 	assert.False(t, isAuthor)
@@ -121,38 +172,38 @@ func TestIsIsFTAuthorFalse(t *testing.T) {
 
 func TestIsGTG(t *testing.T) {
 	m := new(mockAuthorTransformerServer)
-	m.On("Ids", "application/json", "username", "password").Return(http.StatusOK)
+	m.On("Ids", "application/json", "username", "password").Return(http.StatusOK, authorIds)
 	m.On("GTG").Return(http.StatusOK)
 
 	testServer := m.startMockAuthorTransformerServer(t)
 	defer testServer.Close()
 
-	as, err := NewAuthorService(testServer.URL, "username:password", &http.Client{})
+	as, err := NewAuthorService(testServer.URL, "username:password", time.Minute*60, &http.Client{})
 	assert.NoError(t, err, "Creation of a new Author sevice should not return an error")
 	assert.NoError(t, as.IsGTG(), "No GTG errors")
 }
 
 func TestIsNotGTG(t *testing.T) {
 	m := new(mockAuthorTransformerServer)
-	m.On("Ids", "application/json", "username", "password").Return(http.StatusOK)
+	m.On("Ids", "application/json", "username", "password").Return(http.StatusOK, authorIds)
 	m.On("GTG").Return(http.StatusServiceUnavailable)
 
 	testServer := m.startMockAuthorTransformerServer(t)
 	defer testServer.Close()
 
-	as, err := NewAuthorService(testServer.URL, "username:password", &http.Client{})
+	as, err := NewAuthorService(testServer.URL, "username:password", time.Minute*60, &http.Client{})
 	assert.NoError(t, err, "Creation of a new Author sevice should not return an error")
 	assert.EqualError(t, as.IsGTG(), "gtg endpoint returned a non-200 status: 503", "GTG should return 503")
 }
 
 func TestGTGConnectionError(t *testing.T) {
 	m := new(mockAuthorTransformerServer)
-	m.On("Ids", "application/json", "username", "password").Return(http.StatusOK)
+	m.On("Ids", "application/json", "username", "password").Return(http.StatusOK, authorIds)
 	m.On("GTG").Return(http.StatusServiceUnavailable)
 
 	testServer := m.startMockAuthorTransformerServer(t)
 
-	as, err := NewAuthorService(testServer.URL, "username:password", &http.Client{})
+	as, err := NewAuthorService(testServer.URL, "username:password", time.Minute*60, &http.Client{})
 	assert.NoError(t, err, "Creation of a new Author sevice should not return an error")
 	testServer.Close()
 	assert.Error(t, as.IsGTG(), "GTG should return a connection error")
@@ -162,9 +213,9 @@ type mockAuthorTransformerServer struct {
 	mock.Mock
 }
 
-func (m *mockAuthorTransformerServer) Ids(contentType string, user string, password string) int {
+func (m *mockAuthorTransformerServer) Ids(contentType string, user string, password string) (int, string) {
 	args := m.Called(contentType, user, password)
-	return args.Int(0)
+	return args.Int(0), args.String(1)
 }
 
 func (m *mockAuthorTransformerServer) GTG() int {

--- a/service/author_service_test.go
+++ b/service/author_service_test.go
@@ -123,7 +123,7 @@ func TestRefreshAuthorIdentifiersResponseSuccess(t *testing.T) {
 	time.Sleep(time.Millisecond * 35)
 	m.countLock.RLock()
 	defer m.countLock.RUnlock()
-	assert.True(t, m.count >= 4, "author list is not being refreshed onl called"+strconv.Itoa(m.count))
+	assert.True(t, m.count >= 4, "author list is not being refreshed correctly, number of calls made: "+strconv.Itoa(m.count))
 	m.AssertExpectations(t)
 }
 
@@ -148,7 +148,7 @@ func TestRefreshAuthorIdentifiersWithErrorContinues(t *testing.T) {
 	time.Sleep(time.Millisecond * 35)
 	m.countLock.RLock()
 	defer m.countLock.RUnlock()
-	assert.True(t, m.count >= 4, "author list is not being refreshed"+strconv.Itoa(m.count))
+	assert.True(t, m.count >= 4, "author list is not being refreshed correctly, number of calls made:"+strconv.Itoa(m.count))
 
 	m.AssertExpectations(t)
 }

--- a/service/model_conversion_test.go
+++ b/service/model_conversion_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,7 @@ func TestConvertToESConceptModel(t *testing.T) {
 		httpClient:  nil,
 		serviceURL:  "url",
 		authorUUIDs: expectedAuthorUUIDs,
+		authorLock:  &sync.RWMutex{},
 	}
 
 	testModelPopulator := NewEsModelPopulator(&testAuthorService)
@@ -106,6 +108,7 @@ func TestConvertPersonToESConceptModel(t *testing.T) {
 		httpClient:  nil,
 		serviceURL:  "url",
 		authorUUIDs: expectedAuthorUUIDs,
+		authorLock:  &sync.RWMutex{},
 	}
 	testModelPopulator := NewEsModelPopulator(&testAuthorService)
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -49,18 +49,16 @@
 		{
 			"checksumSHA1": "+sjiZBzrsk91W1A3Md1azCkZadg=",
 			"path": "github.com/Financial-Times/transactionid-utils-go",
-			"revision": "df2f00c734957c9dd651ce23ab0e0902504c7636", 
+			"revision": "df2f00c734957c9dd651ce23ab0e0902504c7636",
 			"revisionTime": "2017-03-28T16:39:54Z",
 			"version": "v0.2.0",
-            "versionExact": "v0.2.0"
+			"versionExact": "v0.2.0"
 		},
 		{
-			"checksumSHA1": "Liv7AJyNinmP3pvwohcXp4R6xY4=",
+			"checksumSHA1": "nyO7DwRgPMIdpMKseDeL9hlUQVg=",
 			"path": "github.com/Sirupsen/logrus",
-			"revision": "202f25545ea4cf9b191ff7f846df5d87c9382c2b",
-			"revisionTime": "2017-06-08T21:02:02Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "59d0ca41e5faad81cac03f7a7d84ba80d9cc9673",
+			"revisionTime": "2017-07-06T13:44:07Z"
 		},
 		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",


### PR DESCRIPTION
the logic for this feature is:
on startup  load authors , if the list cannot be obtained stop.
else refresh authors every hour and if the refresh attempt fails use the map in memory.

testing tickers is tricksy and after various attempts this was the best I came up with.