### PR TITLE
Support Intermediate Concept Model

### DIFF
--- a/service/model.go
+++ b/service/model.go
@@ -58,7 +58,7 @@ func (c ConceptModel) PreferredUUID() string {
 func (c ConceptModel) GetAuthorities() []string {
 	var authorities []string
 
-	if c.Authority != "" {
+	if c.AlternativeIdentifiers == nil && c.Authority != "" {
 		return []string{c.Authority}
 	}
 

--- a/service/model.go
+++ b/service/model.go
@@ -14,6 +14,7 @@ type ConceptModel struct {
 	UUID                   string                 `json:"uuid"`
 	DirectType             string                 `json:"type"`
 	PrefLabel              string                 `json:"prefLabel"`
+	Authority              string                 `json:"authority,omitempty"`
 	Aliases                []string               `json:"aliases,omitempty"`
 	AlternativeIdentifiers map[string]interface{} `json:"alternativeIdentifiers,omitempty"`
 }
@@ -56,6 +57,11 @@ func (c ConceptModel) PreferredUUID() string {
 
 func (c ConceptModel) GetAuthorities() []string {
 	var authorities []string
+
+	if c.Authority != "" {
+		return []string{c.Authority}
+	}
+
 	for authority := range c.AlternativeIdentifiers {
 		if authority == "uuids" {
 			continue // exclude the "uuids" alternativeIdentifier

--- a/service/model_conversion_test.go
+++ b/service/model_conversion_test.go
@@ -231,9 +231,8 @@ func TestConceptFuncsForConceptModel(t *testing.T) {
 		assert.Contains(t, actual, val)
 	}
 
-	expected = []string{}
 	actual = concept.ConcordedUUIDs()
-	assert.Equal(t, expected, actual)
+	assert.Empty(t, actual)
 	assert.Equal(t, "2384fa7a-d514-3d6a-a0ea-3a711f66d0d8", concept.PreferredUUID())
 }
 

--- a/service/model_conversion_test.go
+++ b/service/model_conversion_test.go
@@ -14,6 +14,8 @@ var testAggregateConceptModelJSON = `{"prefUUID":"56388858-38d6-4dfc-a001-506394
 
 var testConceptModelJSON = `{"uuid":"2384fa7a-d514-3d6a-a0ea-3a711f66d0d8","type":"PublicCompany","properName":"Apple, Inc.","prefLabel":"Apple, Inc.","legalName":"Apple Inc.","shortName":"Apple","hiddenLabel":"APPLE INC","alternativeIdentifiers":{"TME":["TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04="],"uuids":["2384fa7a-d514-3d6a-a0ea-3a711f66d0d8","2abff0bd-544d-31c3-899b-fba2f60d53dd"],"factsetIdentifier":"000C7F-E","leiCode":"HWUPKR0MPOU8FGXBT394"},"formerNames":["Apple Computer, Inc."],"aliases":["Apple Inc","Apple Computers","Apple","Apple Canada","Apple Computer","Apple Computer, Inc.","APPLE INC","Apple Incorporated","Apple Computer Inc","Apple Inc.","Apple, Inc."],"industryClassification":"7a01c847-a9bd-33be-b991-c6fbd8871a46"}`
 
+var testIntermediateConceptModelJSON = `{"uuid":"7e3f1354-53ba-3c3e-b9bb-5fcb8941df8c","prefLabel":"ICOmedy","type":"AlphavilleSeries","authority":"TME","authorityValue":"NDQ1NjhiMzktMjJmNy00OWEzLWExNDctNDFiNDk4OGU2MTdj-QWxwaGF2aWxsZVNlcmllc0NsYXNzaWZpY2F0aW9u"}`
+
 func newTestModelPopulator() ModelPopulator {
 	testAuthorService := curatedAuthorService{
 		httpClient:  nil,
@@ -233,6 +235,25 @@ func TestConceptFuncsForConceptModel(t *testing.T) {
 	actual = concept.ConcordedUUIDs()
 	assert.Equal(t, expected, actual)
 	assert.Equal(t, "2384fa7a-d514-3d6a-a0ea-3a711f66d0d8", concept.PreferredUUID())
+}
+
+func TestConceptFuncsForIntermediateConceptModel(t *testing.T) {
+	concept := ConceptModel{}
+	err := json.Unmarshal([]byte(testIntermediateConceptModelJSON), &concept)
+	require.NoError(t, err)
+
+	expected := []string{"TME"}
+	actual := concept.GetAuthorities()
+
+	assert.Len(t, actual, 1)
+	for _, val := range expected {
+		assert.Contains(t, actual, val)
+	}
+
+	expected = []string{}
+	actual = concept.ConcordedUUIDs()
+	assert.Equal(t, expected, actual)
+	assert.Equal(t, "7e3f1354-53ba-3c3e-b9bb-5fcb8941df8c", concept.PreferredUUID())
 }
 
 func TestConceptFuncsForAggregatedConceptModel(t *testing.T) {


### PR DESCRIPTION
The basic-tme-transformer does not output concepts in either the new or old concept model formats, and instead outputs the intermediary model i.e.:

```
{
   "uuid": "7e3f1354-53ba-3c3e-b9bb-5fcb8941df8c",
   "prefLabel": "ICOmedy",
   "type": "AlphavilleSeries",
   "authority": "TME",
   "authorityValue": "NDQ1NjhiMzktMjJmNy00OWEzLWExNDctNDFiNDk4OGU2MTdj-QWxwaGF2aWxsZVNlcmllc0NsYXNzaWZpY2F0aW9u"
}
```

So we should support them