### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Concept RW Elasticsearch
 
 Concept RW ElasticSearch is an application that writes concepts into Amazon Elasticsearch cluster in batches. It is also used to update concepts metrics as part of a regular cron job that keeps concepts search up to date.
@@ -8,7 +12,7 @@ up-crwes
 
 ## Primary URL
 
-<https://upp-prod-delivery-glb.upp.ft.com/__concept-rw-elasticsearch>
+https://upp-prod-delivery-glb.upp.ft.com/__concept-rw-elasticsearch
 
 ## Service Tier
 
@@ -17,22 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- ivan.nikolov
-- marina.chompalova
-- miroslav.gatsanoga
-- elitsa.pavlova
-- kalin.arsov
 
 ## Host Platform
 
@@ -50,9 +38,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- concept-elasticsearch-cluster
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -90,6 +88,14 @@ Manual
 
 The release is triggered by making a Github release which is then picked up by a Jenkins multibranch pipeline. The Jenkins pipeline should be manually started in order for it to deploy the helm package to the Kubernetes clusters.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -102,8 +108,8 @@ In order to get access to ElasticSearch the service uses credentials from the `c
 
 Pod health:
 
-- <https://upp-prod-delivery-eu.ft.com/__health/__pods-health?service-name=concept-rw-elasticsearch>
-- <https://upp-prod-delivery-us.ft.com/__health/__pods-health?service-name=concept-rw-elasticsearch>
+*   <https://upp-prod-delivery-eu.ft.com/__health/__pods-health?service-name=concept-rw-elasticsearch>
+*   <https://upp-prod-delivery-us.ft.com/__health/__pods-health?service-name=concept-rw-elasticsearch>
 
 ## First Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/concept-rw-elasticsearch/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **up-crwes** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **up-crwes** system in [Biz Ops](https://biz-ops.in.ft.com/System/up-crwes).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
