### PR TITLE
disable HTTP/2

### DIFF
--- a/service/es_client.go
+++ b/service/es_client.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -56,8 +57,12 @@ func (a AWSSigningTransport) RoundTrip(req *http.Request) (*http.Response, error
 func newAmazonClient(config EsAccessConfig, region string) (*elastic.Client, error) {
 	signingTransport := AWSSigningTransport{
 		Credentials: config.awsCreds,
-		HTTPClient:  http.DefaultClient,
-		Region:      region,
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				TLSNextProto: map[string]func(string, *tls.Conn) http.RoundTripper{},
+			},
+		},
+		Region: region,
 	}
 	signingClient := &http.Client{Transport: http.RoundTripper(signingTransport)}
 


### PR DESCRIPTION
# Description

## What

Disable HTTP2 to prevent errors when concept-rw-elasticsearch is under heavy load.
Here is a link to the source of the [fix](https://github.com/olivere/elastic/issues/1443#issuecomment-990187248).
This was deployed on staging us to monitor if it fixes the problem.
Here is a splunk query where we have failures on [staging EU](https://financialtimes.splunkcloud.com/en-GB/app/financial_times_production/search?display.page.search.mode=fast&dispatch.sample_ratio=1&q=search%20index%3D%22content_prod%22%20environment%3D%22upp-staging-delivery-eu%22%20SERVICE_NAME%3Dconcept-rw-elasticsearch%20%22ERROR%22%20OR%20%22level%3Derror%22%20OR%20%22failed%22&earliest=1686268800&latest=1686441600&workload_pool=standard_perf&sid=1686574468.17799242).

Here is the [same query ](https://financialtimes.splunkcloud.com/en-GB/app/financial_times_production/search?display.page.search.mode=fast&dispatch.sample_ratio=1&q=search%20index%3D%22content_prod%22%20environment%3D%22upp-staging-delivery-eu%22%20SERVICE_NAME%3Dconcept-rw-elasticsearch%20%22ERROR%22%20OR%20%22level%3Derror%22%20OR%20%22failed%22&earliest=1686268800&latest=1686441600&workload_pool=standard_perf&sid=1686574468.17799242)for the same period on US.
## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4446)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
