### PR TITLE
Change the aggregated concept schema

### DIFF
--- a/service/es_model_populator.go
+++ b/service/es_model_populator.go
@@ -53,14 +53,17 @@ func ConvertAggregateConceptToESConceptModel(concept AggregateConceptModel, conc
 
 	switch conceptType {
 	case memberships:
+		if len(concept.PersonUUID) != 1 || len(concept.OrganisationUUID) != 1 {
+			return nil, fmt.Errorf("ambiguous membership concept '%s', it has more than one HAS_MEMBER or HAS_ORGANISATION relationships", concept.PreferredUUID())
+		}
 		ms := make([]string, len(concept.MembershipRoles))
 		for i, m := range concept.MembershipRoles {
 			ms[i] = m.RoleUUID
 		}
 		esModel = &EsMembershipModel{
 			Id:             concept.PrefUUID,
-			PersonId:       concept.PersonUUID,
-			OrganisationId: concept.OrganisationUUID,
+			PersonId:       concept.PersonUUID[0],
+			OrganisationId: concept.OrganisationUUID[0],
 			Memberships:    ms,
 		}
 	case person:

--- a/service/model.go
+++ b/service/model.go
@@ -39,8 +39,8 @@ type AggregateConceptModel struct {
 	ScopeNote string   `json:"scopeNote,omitempty"`
 	// Membership
 	MembershipRoles  []AggregateMembershipRole `json:"membershipRoles,omitempty"`
-	OrganisationUUID string                    `json:"organisationUUID,omitempty"`
-	PersonUUID       string                    `json:"personUUID,omitempty"`
+	OrganisationUUID []string                  `json:"organisationUUID,omitempty"`
+	PersonUUID       []string                  `json:"personUUID,omitempty"`
 	// Organisation
 	CountryCode            string `json:"countryCode,omitempty"`
 	CountryOfIncorporation string `json:"countryOfIncorporation,omitempty"`

--- a/service/model_conversion_test.go
+++ b/service/model_conversion_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
-
 	"time"
 
 	tid "github.com/Financial-Times/transactionid-utils-go"
@@ -474,8 +473,8 @@ func TestConvertMembershipToAggregateConceptModel(t *testing.T) {
 			testName: "basic membership",
 			aggregateConceptModel: AggregateConceptModel{
 				PrefUUID:         "b159a539-527e-42ba-b5ee-29c33c0e016a",
-				PersonUUID:       "d52d8fdf-656c-4db3-b27c-06b16cdbb580",
-				OrganisationUUID: "fa2b743d-f535-4deb-8524-df65bd536d09",
+				PersonUUID:       []string{"d52d8fdf-656c-4db3-b27c-06b16cdbb580"},
+				OrganisationUUID: []string{"fa2b743d-f535-4deb-8524-df65bd536d09"},
 				MembershipRoles: []AggregateMembershipRole{
 					{RoleUUID: "c55f1d31-00fc-47a5-8a2e-19a967e07955", InceptionDate: "InceptionDate", TerminationDate: "TerminationDate"},
 					{RoleUUID: "5c1f6da5-596e-4853-89b9-7f08652d366a", InceptionDate: "InceptionDate"},
@@ -492,8 +491,8 @@ func TestConvertMembershipToAggregateConceptModel(t *testing.T) {
 			testName: "empty membership",
 			aggregateConceptModel: AggregateConceptModel{
 				PrefUUID:         "b159a539-527e-42ba-b5ee-29c33c0e016a",
-				PersonUUID:       "d52d8fdf-656c-4db3-b27c-06b16cdbb580",
-				OrganisationUUID: "fa2b743d-f535-4deb-8524-df65bd536d09",
+				PersonUUID:       []string{"d52d8fdf-656c-4db3-b27c-06b16cdbb580"},
+				OrganisationUUID: []string{"fa2b743d-f535-4deb-8524-df65bd536d09"},
 			},
 			esMembershipModel: EsMembershipModel{
 				Id:             "b159a539-527e-42ba-b5ee-29c33c0e016a",


### PR DESCRIPTION
# Description

## What

With the introduction of the ontology V2 the aggregated concept schema was changed. Now the aggregated concept contains aggregated relationships of all source concepts. This includes HAS_MEMBER and HAS_ORGANIZATION relationships that are used by this service to handle membership writes.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-4477

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
