### PR TITLE
Feature/uppsf 5546 exclude ft pink authorities option on ids endpoint

### DIFF
--- a/health/healthcheck_test.go
+++ b/health/healthcheck_test.go
@@ -332,7 +332,7 @@ func parseHealthcheck(healthcheckJSON string) ([]fthealth.CheckResult, error) {
 	return result.Checks, err
 }
 
-func (m *EsServiceMock) GetAllIds(ctx context.Context, includeTypes bool) chan service.EsIDTypePair {
+func (m *EsServiceMock) GetAllIDs(_ context.Context, _ bool, _ bool) chan service.EsIDTypePair {
 	args := m.Called()
 	return args.Get(0).(chan service.EsIDTypePair)
 }

--- a/helm/concept-rw-elasticsearch/templates/deployment.yaml
+++ b/helm/concept-rw-elasticsearch/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: LOG_LEVEL
           value: {{ .Values.env.LOG_LEVEL}}
         - name: ELASTICSEARCH_INDEX
-          value: all-concepts
+          value: concepts
         - name: ELASTICSEARCH_WHITELISTED_CONCEPTS
           value: "genres,topics,sections,subjects,locations,brands,organisations,people,alphaville-series,memberships,sv-categories,sv-provisions,fta-brands,fta-genres,fta-topics"
         - name: ELASTICSEARCH_ENDPOINT

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func routeRequests(port *string, handler *resources.Handler, healthService *heal
 	servicesRouter.HandleFunc("/{concept-type}/{id}", handler.LoadData).Methods("PUT")
 	servicesRouter.HandleFunc("/{concept-type}/{id}", handler.ReadData).Methods("GET")
 	servicesRouter.HandleFunc("/{concept-type}/{id}", handler.DeleteData).Methods("DELETE")
-	servicesRouter.HandleFunc("/__ids", handler.GetAllIds).Methods("GET")
+	servicesRouter.HandleFunc("/__ids", handler.GetAllIDs).Methods("GET")
 
 	var monitoringRouter http.Handler = servicesRouter
 	monitoringRouter = httphandlers.TransactionAwareRequestLoggingHandler(log.StandardLogger(), monitoringRouter)

--- a/resources/handler.go
+++ b/resources/handler.go
@@ -304,15 +304,16 @@ func (h *Handler) DeleteData(writer http.ResponseWriter, request *http.Request) 
 	writer.WriteHeader(http.StatusOK)
 }
 
-func (h *Handler) GetAllIds(writer http.ResponseWriter, request *http.Request) {
+func (h *Handler) GetAllIDs(writer http.ResponseWriter, request *http.Request) {
 	transactionID := tid.GetTransactionIDFromRequest(request)
 	ctx := tid.TransactionAwareContext(context.Background(), transactionID)
 
 	includeTypes := strings.ToLower(request.URL.Query().Get("includeTypes")) == "true"
+	excludeFTPinkAuthorities := strings.ToLower(request.URL.Query().Get("excludeFTPinkAuthorities")) == "true"
 
 	writer.Header().Set("Content-Type", "text/plain")
 	writer.WriteHeader(http.StatusOK)
-	ids := h.elasticService.GetAllIds(ctx, includeTypes)
+	ids := h.elasticService.GetAllIDs(ctx, includeTypes, excludeFTPinkAuthorities)
 	i := 0
 	for id := range ids {
 		if includeTypes {

--- a/resources/handler_test.go
+++ b/resources/handler_test.go
@@ -550,7 +550,7 @@ func TestIDsEndpointReturnsIDsWithInvalidIncludeTypesValue(t *testing.T) {
 		close(ids)
 	}()
 
-	h.GetAllIds(w, req)
+	h.GetAllIDs(w, req)
 
 	for {
 		line, err := w.Body.ReadString('\n')
@@ -583,7 +583,7 @@ func TestIDsEndpointReturnsTypes(t *testing.T) {
 		close(ids)
 	}()
 
-	h.GetAllIds(w, req)
+	h.GetAllIDs(w, req)
 
 	for {
 		line, err := w.Body.ReadString('\n')
@@ -658,6 +658,6 @@ func (service *dummyEsService) GetClusterHealth() (*elastic.ClusterHealthRespons
 	return nil, nil
 }
 
-func (service *dummyEsService) GetAllIds(ctx context.Context, includeTypes bool) chan service.EsIDTypePair {
+func (service *dummyEsService) GetAllIDs(_ context.Context, _ bool, _ bool) chan service.EsIDTypePair {
 	return service.ids
 }

--- a/service/es_service.go
+++ b/service/es_service.go
@@ -36,6 +36,7 @@ const (
 	columnistUUID      = "7ef75a6a-b6bf-4eb7-a1da-03e0acabef1b"
 	journalistUUID     = "33ee38a4-c677-4952-a141-2ae14da3aedd"
 	notFoundResult     = "not_found"
+	allConceptsAlias   = "all-concepts"
 )
 
 type esService struct {
@@ -57,7 +58,7 @@ type EsService interface {
 	CloseBulkProcessor() error
 	GetClusterHealth() (*elastic.ClusterHealthResponse, error)
 	IsIndexReadOnly() (bool, string, error)
-	GetAllIds(ctx context.Context, includeTypes bool) chan EsIDTypePair
+	GetAllIDs(ctx context.Context, includeTypes bool, excludeFTPinkAuthorities bool) chan EsIDTypePair
 }
 
 func NewEsService(ch chan *elastic.Client, indexName string, bulkProcessorConfig *BulkProcessorConfig) EsService {
@@ -412,18 +413,28 @@ func (es *esService) CloseBulkProcessor() error {
 	return es.bulkProcessor.Close()
 }
 
-func (es *esService) GetAllIds(ctx context.Context, includeTypes bool) chan EsIDTypePair {
+func (es *esService) GetAllIDs(ctx context.Context, includeTypes bool, excludeFTPinkAuthorities bool) chan EsIDTypePair {
 	ids := make(chan EsIDTypePair)
 
 	go func() {
 		defer close(ids)
-
-		r := elastic.NewScrollService(es.elasticClient).
-			Index(es.indexName).
-			Query(elastic.NewMatchAllQuery()).
-			Sort("_doc", true).
-			Size(1000).
-			FetchSource(includeTypes)
+		var r *elastic.ScrollService
+		if excludeFTPinkAuthorities {
+			r = elastic.NewScrollService(es.elasticClient).
+				Index(allConceptsAlias).
+				Query(elastic.NewBoolQuery().
+					MustNot(elastic.NewTermsQuery("authorities", "TME", "Smartlogic"))).
+				Sort("_doc", true).
+				Size(1000).
+				FetchSource(includeTypes)
+		} else {
+			r = elastic.NewScrollService(es.elasticClient).
+				Index(es.indexName).
+				Query(elastic.NewMatchAllQuery()).
+				Sort("_doc", true).
+				Size(1000).
+				FetchSource(includeTypes)
+		}
 
 		es.RLock()
 		defer es.RUnlock()

--- a/service/es_service_integration_test.go
+++ b/service/es_service_integration_test.go
@@ -775,7 +775,7 @@ func TestMetricsUpdated(t *testing.T) {
 	assert.Equal(t, testMetrics.Metrics.PrevWeekAnnotationsCount, actualModel.Metrics.PrevWeekAnnotationsCount, "PrevWeekAnnotationsCount should be set")
 }
 
-func TestGetAllIds(t *testing.T) {
+func TestGetAllIDs(t *testing.T) {
 	esURL := getElasticSearchTestURL()
 	ec := getElasticClient(t, esURL)
 	bulkProcessorConfig := NewBulkProcessorConfig(1, 1, 1, time.Second)
@@ -811,7 +811,7 @@ func TestGetAllIds(t *testing.T) {
 	_, err := ec.Refresh(indexName).Do(context.Background())
 	require.NoError(t, err, "expected successful flush")
 
-	ch := service.GetAllIds(context.Background(), false)
+	ch := service.GetAllIDs(context.Background(), false, false)
 	actual := make(map[string]struct{})
 	for id := range ch {
 		actual[id.ID] = struct{}{}


### PR DESCRIPTION
# Description

## What

Parameterise the ids endpoint to allow retrieving concepts from the all-concepts index excluding concept containing TME or Smartlogic authorities.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-5573)
## Anything, in particular, you'd like to highlight to reviewers

**IMPORTANT: Keep using the `concepts` index as default behaviour to not repeat the initial issue.**

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
